### PR TITLE
Auto Open Chest Changed

### DIFF
--- a/PandorasBox/Features/Targets/AutoOpenChests.cs
+++ b/PandorasBox/Features/Targets/AutoOpenChests.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game;
 using Dalamud.Logging;
 using ECommons.DalamudServices;
+using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -24,7 +25,7 @@ namespace PandorasBox.Features.Targets
 
         public class Configs : FeatureConfig
         {
-            [FeatureConfigOption("Set delay (seconds)", FloatMin = 0, FloatMax = 10f, EditorSize = 300, EnforcedLimit = true)]
+            [FeatureConfigOption("Set delay (seconds)", FloatMin = 0.1f, FloatMax = 10f, EditorSize = 300, EnforcedLimit = true)]
             public float Throttle = 0.1f;
 
             [FeatureConfigOption("Immediately Close Loot Window After Opening")]
@@ -66,7 +67,8 @@ namespace PandorasBox.Features.Targets
                 TaskManager.DelayNext("Chests", (int)(Config.Throttle * 1000));
                 TaskManager.Enqueue(() =>
                 {
-                    if (GameObjectHelper.GetTargetDistance(nearestNode) > 2) return true;
+                    if (GameObjectHelper.GetTargetDistance(nearestNode) > 0.5f) return true;
+
                     TargetSystem.Instance()->InteractWithObject(baseObj, true);
                     if (Config.CloseLootWindow)
                     {


### PR DESCRIPTION
Make it only open the chest that is not opened.

NOTICE: Without tests! I am at work...

https://github.com/PunishXIV/PandorasBox/blob/3d1646f6f6f86cf8b3d3e41a1b45878d7c95a398/PandorasBox/Features/Targets/AutoOpenChests.cs#L83-L102
Besides, this part of the code has an issue found by me. If it auto-close the loot window, and then the user wants to open it. He/she needs to click the chest button in Notification twice. I think it may be due to that the Notification doesn't know it was closed.
So I recommended changing this code back to this.
https://github.com/PunishXIV/PandorasBox/blob/251587eca53a5a2d9adf49d3a623a01bbc34e808/PandorasBox/Features/Targets/AutoOpenChests.cs#L82-L108
