### PR TITLE
[Feature Mods] Make AutoActions (Card draw/summons) work after revive

### DIFF
--- a/PandorasBox/Features/Actions/AutoFairy.cs
+++ b/PandorasBox/Features/Actions/AutoFairy.cs
@@ -50,7 +50,7 @@ namespace PandorasBox.Features.Actions
                 TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Unconscious], "CheckConditionUnconscious");
                 TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.BetweenAreas], "CheckConditionBetweenAreas");
                 TaskManager.DelayNext("WaitForActionReady", 1000);
-                TaskManager.Enqueue(() => TrySummon(Svc.ClientState.LocalPlayer.ClassJob.Id), 5000);
+                TaskManager.Enqueue(() => TrySummon(Svc.ClientState.LocalPlayer?.ClassJob.Id), 5000);
             }
         }
 

--- a/PandorasBox/Features/Actions/AutoFairy.cs
+++ b/PandorasBox/Features/Actions/AutoFairy.cs
@@ -1,3 +1,4 @@
+using Dalamud.Game.ClientState.Conditions;
 using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using ImGuiNET;
@@ -26,6 +27,7 @@ namespace PandorasBox.Features.Actions
         {
             Config = LoadConfig<Configs>() ?? new Configs();
             OnJobChanged += RunFeature;
+            Svc.Condition.ConditionChange += CheckIfRespawned;
             base.Enable();
         }
 
@@ -37,6 +39,18 @@ namespace PandorasBox.Features.Actions
                 TaskManager.Abort();
                 TaskManager.DelayNext("Summoning", (int)(Config.ThrottleF * 1000));
                 TaskManager.Enqueue(() => TrySummon(jobId), 5000);
+            }
+        }
+
+        private void CheckIfRespawned(ConditionFlag flag, bool value)
+        {
+            if (flag == Dalamud.Game.ClientState.Conditions.ConditionFlag.Unconscious && !value)
+            {
+                TaskManager.DelayNext("WaitForConditions", (int)(Config.ThrottleF * 1000));
+                TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Unconscious], "CheckConditionUnconscious");
+                TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.BetweenAreas], "CheckConditionBetweenAreas");
+                TaskManager.DelayNext("WaitForActionReady", 1000);
+                TaskManager.Enqueue(() => TrySummon(Svc.ClientState.LocalPlayer.ClassJob.Id), 5000);
             }
         }
 
@@ -62,6 +76,7 @@ namespace PandorasBox.Features.Actions
         {
             SaveConfig(Config);
             OnJobChanged -= RunFeature;
+            Svc.Condition.ConditionChange -= CheckIfRespawned;
             base.Disable();
         }
 


### PR DESCRIPTION
There is a small period of time after becoming conscious that you cannot execute an action, so this wouldn't work if you had your delay set really low (i.e. 0.1). I just added a forced WaitForActionReady delay of a second. Might be another way around this, but via conditions I don't think so.

Also, the delay is one second and current not customisable. Not sure if it's needed, potentially for people on lower power machines where the delay might not be enough, but it worked 100% of the time for me.