### PR TITLE
Skip QuickLowerQuality check if SeString doesn't match expected pattern

### DIFF
--- a/PandorasBox/Features/UI/QuickLowerQuality.cs
+++ b/PandorasBox/Features/UI/QuickLowerQuality.cs
@@ -33,6 +33,10 @@ namespace PandorasBox.Features.UI
             if (obj.AddonName == "SelectYesno")
             {
                 var seString = MemoryHelper.ReadSeStringNullTerminated(new IntPtr(obj.Addon->AtkValues[0].String));
+                if (seString.Payloads.Count < 3 || seString.Payloads[2] is not TextPayload)
+                {
+                    return;
+                }
                 var sheetText = Svc.Data.GetExcelSheet<Addon>().Where(x => x.RowId == 155).First().Text.Payloads[2].RawString.Trim();
                 var rawText = ((TextPayload)seString.Payloads[2]).Text.Trim();
                 var trimmedText = rawText.Remove(rawText.LastIndexOf(' ')).TrimEnd();


### PR DESCRIPTION
Currently, the quick lower quality feature attempts to index/read a `SeString` payload without checking its existence/type first. For example, the "open door" prompts in Copperbell Mines and various other dungeons have a different payload structure when compared to desynth prompts. This result in the following kinds of exceptions being logged:

```
ERR [PandorasBox] AddonSetupError2
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at PandorasBox.Features.UI.QuickLowerQuality.Common_AddonSetup(SetupAddonArgs obj) in C:\Users\thero\source\repos\PandorasBox\PandorasBox\Features\UI\QuickLowerQuality.cs:line 33
   at PandorasBox.Common.AddonSetupDetour(AtkUnitBase* addon) in C:\Users\thero\source\repos\PandorasBox\PandorasBox\FeaturesSetup\Common.cs:line 79
```

This isn't a big issue as the exception is merely caught and logged, but it does create some noise in the plugin log. This PR avoids the error by first making sure the payload matches the expected pattern before continuing.

Thanks.