### PR TITLE
Null check AddonGathering

### DIFF
--- a/PandorasBox/Features/Other/PandoraGathering.cs
+++ b/PandorasBox/Features/Other/PandoraGathering.cs
@@ -586,6 +586,8 @@ namespace PandorasBox.Features.Other
                 {
                     var addon = (AddonGathering*)Svc.GameGui.GetAddonByName("Gathering", 1);
 
+                    if (addon == null) return;
+
                     var ids = new List<uint>();
                     for (int i = 7; i <= (11 * 8) + 7; i += 11)
                     {


### PR DESCRIPTION
If the addon gets closed before the task runs our reference is invalid

Error on current release build:
```
14:41:45.399 | ERR | [PandorasBox] Object reference not set to an instance of an object.
	   at PandorasBox.Features.Other.PandoraGathering.<>c__DisplayClass48_0.<AddonSetup>b__1() in C:\Users\thero\source\repos\PandorasBox\PandorasBox\Features\Other\PandoraGathering.cs:line 590
	   at ECommons.Automation.LegacyTaskManager.TaskManager.<>c__DisplayClass37_0.<Enqueue>b__0() in C:\Users\thero\source\repos\PandorasBox\ECommons\ECommons\Automation\LegacyTaskManager\TaskManager@Enqueue.cs:line 63
	   at ECommons.Automation.LegacyTaskManager.TaskManager.Tick(Object _) in C:\Users\thero\source\repos\PandorasBox\ECommons\ECommons\Automation\LegacyTaskManager\TaskManager.cs:line 141
```