### PR TITLE
[Enhance][AutoVoteMvp] Allow manual commendation selection/override and exclusions via context menu

### DIFF
--- a/PandorasBox/Features/UI/AutoVoteMvp.cs
+++ b/PandorasBox/Features/UI/AutoVoteMvp.cs
@@ -11,11 +11,13 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
+using Lumina.Excel.Sheets;
 using PandorasBox.FeaturesSetup;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using static FFXIVClientStructs.FFXIV.Client.UI.AddonRelicNoteBook;
 
 namespace PandorasBox.Features.UI;
 
@@ -77,15 +79,17 @@ public class AutoVoteMvp : Feature
         base.Enable();
     }
 
-    private void CommendContextMenu(IMenuOpenedArgs args)
+    private unsafe void CommendContextMenu(IMenuOpenedArgs args)
     {
         if (!Config.ShowContextMenu) return;
-        if (args.AddonName != "_PartyList") return;
+        if (!(args.AddonName == "_PartyList" || args.AddonName == "ChatLog")) return;
         if (Svc.ClientState.IsPvP) return;
         if (!Svc.Condition.Any(Dalamud.Game.ClientState.Conditions.ConditionFlag.BoundByDuty)) return;
         var argItem = (MenuTargetDefault)args.Target;
         if (argItem == null) return;
         if (PremadePartyID.Any(y => y == argItem.TargetName)) return;
+        if (!Svc.Party.Cast<IPartyMember>()
+            .Any(m => ((FFXIVClientStructs.FFXIV.Client.Game.Group.PartyMember*)m.Address)->NameString == argItem.TargetName)) return;
         if (!(CommendExclusions?.Contains(argItem.TargetName) ?? false))
         {
             var item = CreateCommendPlayerMenuItem(argItem.TargetName);


### PR DESCRIPTION
This PR adds manual control over commendation behavior via new context menu options.

**✨ Features:**
- Adds a context menu option on party members during duties to **manually select a player** to automatically commend at the end of the duty, overriding random selection.
- Adds a context menu option to **exclude a player** from being randomly selected for commendation if you do not want to commend them.
  - Manual commendation and exclusion are mutually exclusive (a player cannot be both selected and excluded at the same time).
- Added a config setting to toggle the context menu options on or off.

**🔧 Side improvements:**
- Improved fallback logic: if all party members are excluded (e.g., by user action), a final random selection using original available party members list will be made to attempt to ensure a commendation is still given if possible.



**🔎 Motivation:**
AutoVoteMvp previously only allowed random or condition-based commendations (such as prioritizing tanks, DPS, or avoiding players who died).
However, there was no way for the user to exercise manual control mid-duty — for example, to commend someone who was especially helpful, friendly, or performed very well.
If a specific commendation was desired, the only option was to temporarily disable the auto-commend feature entirely mid-run.
Similarly, if a party member behaved poorly, users had no way to exclude them from being randomly selected without also disabling the feature.
This change introduces simple, in-duty options to manually select a player to commend or exclude a player from being commended, without having to open configuration menus mid-run.