### PR TITLE
Fix ArgumentOutOfRangeException in QuickLowerQuality

### DIFF
--- a/PandorasBox/Features/UI/QuickLowerQuality.cs
+++ b/PandorasBox/Features/UI/QuickLowerQuality.cs
@@ -35,7 +35,10 @@ namespace PandorasBox.Features.UI
                 return;
             }
             var rawText = payload2.Text!.Trim();
-            var trimmedText = rawText.Remove(rawText.LastIndexOf(' ')).TrimEnd();
+            var lastSpace = rawText.LastIndexOf(' ');
+            var trimmedText = lastSpace >= 0
+                ? rawText.Remove(lastSpace).TrimEnd()
+                : rawText.TrimEnd();
             var sheetText = Svc.Data.GetExcelSheet<Addon>()!.First(x => x.RowId == 155).Text.ToDalamudString().Payloads[2].ToString().Trim();
 
             if (sheetText == trimmedText)


### PR DESCRIPTION
When payload2.Text does not contain a space character, the call to rawText.LastIndexOf(' ') returns -1. Passing -1 to Remove() results in the following exception: 
System.ArgumentOutOfRangeException: StartIndex cannot be less than zero. (Parameter 'startIndex')

Now check whether LastIndexOf(' ') returns a non-negative index before calling Remove(). If it returns -1, simply use TrimEnd() on the original text.