### PR TITLE
AFKTimer error spam fix

### DIFF
--- a/PandorasBox/FeaturesSetup/AFKTimer.cs
+++ b/PandorasBox/FeaturesSetup/AFKTimer.cs
@@ -15,14 +15,17 @@ namespace PandorasBox.FeaturesSetup
 
         private static unsafe void UpdateTimer(IFramework framework)
         {
-            if (Player.IsMoving || Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat])
+            if (Player.AvailableThreadSafe)
             {
-                if (!Stopwatch.IsRunning)
-                    Stopwatch.Restart();
-            }
-            else
-            {
-                Stopwatch.Reset();
+                if (Player.IsMoving || Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat])
+                {
+                    if (!Stopwatch.IsRunning)
+                        Stopwatch.Restart();
+                }
+                else
+                {
+                    Stopwatch.Reset();
+                }
             }
         }
 


### PR DESCRIPTION
Fix for AFK timer, ensure player object is valid before running to prevent null reference error spam on login screen and during area transitions.