### PR TITLE
[QuickPlateLink] Fix role typo.

### DIFF
--- a/PandorasBox/Features/Commands/QuickPlateLink.cs
+++ b/PandorasBox/Features/Commands/QuickPlateLink.cs
@@ -32,7 +32,7 @@ namespace PandorasBox.Features.Commands
         }
 
         private readonly List<Gearset> gearsets = new();
-        private readonly List<string> roles = new() { "tanks", "healers", "dps", "ranged", "casters", "magical ranged", "melees", "physical ranged", "doh", "crafters", "doh", "gatherers" };
+        private readonly List<string> roles = new() { "tanks", "healers", "dps", "ranged", "casters", "magical ranged", "melees", "physical ranged", "doh", "crafters", "dol", "gatherers" };
         private List<ClassJob> jobsList = new();
         protected override void OnCommand(List<string> args)
         {


### PR DESCRIPTION
Pls, it lets me doh to dol instead of doh to gatherers pls plspls